### PR TITLE
Fix learn more and footer target blank

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -16,7 +16,7 @@ slug: home
   </div>
   <div class="row">
     <div class="col-md-12 learn-more-text">
-      <h4 class="text-center">Learn more</h4>
+      <h5 class="text-center">Learn more</h5>
       <p class="text-center"><i class="fas fa-chevron-down fa-2x scroll-down"></i></p>
     </div>
   </div>

--- a/source/layouts/_footer.erb
+++ b/source/layouts/_footer.erb
@@ -11,13 +11,13 @@
   <div class="container padded-top">
     <div class="row padded-above">
       <div class="col">
-        <% link_to 'https://github.com/atomic-loans' do %>
+        <% link_to 'https://github.com/atomic-loans', target: :_blank do %>
           <i class="fab fa-4x fa-github"></i>
         <% end %>
-        <% link_to 'https://medium.com/atomic-loans' do %>
+        <% link_to 'https://medium.com/atomic-loans', target: :_blank do %>
           <i class="fab fa-4x fa-medium"></i>
         <% end %>
-        <% link_to 'https://web.telegram.org/#/im?p=@atomic_loans' do %>
+        <% link_to 'https://web.telegram.org/#/im?p=@atomic_loans', target: :_blank do %>
           <i class="fab fa-4x fa-twitter"></i>
         <% end %>
       </div>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -29,6 +29,10 @@ h4 {
   line-height: 2rem;
 }
 
+h5 {
+  font-weight: 400;
+}
+
 p {
   margin-bottom: 2px;
 }


### PR DESCRIPTION
This PR reduces the font size of learn more and makes footer icons open in new tab using `target: blank`